### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
             9.0.x
       

--- a/BusinessMonitor.MailTools.Dns/BusinessMonitor.MailTools.Dns.csproj
+++ b/BusinessMonitor.MailTools.Dns/BusinessMonitor.MailTools.Dns.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BusinessMonitor.MailTools.Test/BusinessMonitor.MailTools.Test.csproj
+++ b/BusinessMonitor.MailTools.Test/BusinessMonitor.MailTools.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net48;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net48;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/BusinessMonitor.MailTools/BusinessMonitor.MailTools.csproj
+++ b/BusinessMonitor.MailTools/BusinessMonitor.MailTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>
@@ -27,10 +27,6 @@
     <None Include="../README.md" Pack="true" PackagePath="/" />
 
     <InternalsVisibleTo Include="BusinessMonitor.MailTools.Test" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
.NET 6 recently became [end-of-life](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) with the release of .NET 9. This pull request raises the minimum framework version to .NET 8 LTS for future version, and also removes all end-of-life frameworks from the tests.

The `Microsoft.SourceLink.GitHub` package has also been removed since this has been included with the SDK since .NET 8.