### PR TITLE
Add avatar preference tag

### DIFF
--- a/BusinessMonitor.MailTools.Test/BimiTests.cs
+++ b/BusinessMonitor.MailTools.Test/BimiTests.cs
@@ -31,6 +31,25 @@ namespace BusinessMonitor.MailTools.Test
         }
 
         [Test]
+        public void TestAvatar()
+        {
+            var record = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; s=personal");
+
+            Assert.That(record, Is.Not.Null);
+            Assert.That(record.AvatarPreference, Is.EqualTo(AvatarPreference.Personal));
+
+            var record2 = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; s=bimi");
+
+            Assert.That(record2, Is.Not.Null);
+            Assert.That(record2.AvatarPreference, Is.EqualTo(AvatarPreference.Bimi));
+
+            var record3 = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg");
+
+            Assert.That(record3, Is.Not.Null);
+            Assert.That(record3.AvatarPreference, Is.EqualTo(AvatarPreference.Bimi));
+        }
+
+        [Test]
         public void TestLookup()
         {
             var resolver = new DummyResolver("default._bimi.businessmonitor.nl", "v=BIMI1; l=https://businessmonitor.nl/logo.svg");
@@ -48,6 +67,7 @@ namespace BusinessMonitor.MailTools.Test
         [TestCase("v=BIMI1; l=invalidlink")]
         [TestCase("v=BIMI1; a=invalidlink l=https://businessmonitor.nl/logo.svg")]
         [TestCase("v=BIMI1; l=http://nothttpstransport")]
+        [TestCase("v=BIMI1; l=https://example.com/logo.svg; s=invalid")]
         public void TestInvalid(string value)
         {
             Assert.Throws<BimiInvalidException>(() =>

--- a/BusinessMonitor.MailTools/Bimi/AvatarPreference.cs
+++ b/BusinessMonitor.MailTools/Bimi/AvatarPreference.cs
@@ -1,0 +1,8 @@
+﻿namespace BusinessMonitor.MailTools.Bimi
+{
+    public enum AvatarPreference
+    {
+        Personal,
+        Bimi
+    }
+}

--- a/BusinessMonitor.MailTools/Bimi/BimiCheck.cs
+++ b/BusinessMonitor.MailTools/Bimi/BimiCheck.cs
@@ -111,6 +111,12 @@ namespace BusinessMonitor.MailTools.Bimi
                         record.Location = val;
 
                         break;
+
+                    // Avatar Preference
+                    case "s":
+                        record.AvatarPreference = GetAvatarPreference(val);
+
+                        break;
                 }
             }
 
@@ -147,6 +153,16 @@ namespace BusinessMonitor.MailTools.Bimi
             {
                 throw new BimiInvalidException($"BIMI record {type} is invalid, transport must be HTTPS");
             }
+        }
+
+        private static AvatarPreference GetAvatarPreference(string value)
+        {
+            if (value != "personal" && value != "bimi")
+            {
+                throw new BimiInvalidException("Invalid avatar preference, must be personal or bimi");
+            }
+
+            return value == "personal" ? AvatarPreference.Personal : AvatarPreference.Bimi;
         }
     }
 }

--- a/BusinessMonitor.MailTools/Bimi/BimiRecord.cs
+++ b/BusinessMonitor.MailTools/Bimi/BimiRecord.cs
@@ -9,6 +9,7 @@
         {
             Evidence = "";
             Location = null;
+            AvatarPreference = AvatarPreference.Bimi;
         }
 
         /// <summary>
@@ -20,5 +21,10 @@
         /// Gets the location of the Brand Indicator file
         /// </summary>
         public string? Location { get; internal set; }
+
+        /// <summary>
+        /// Gets the avatar preference
+        /// </summary>
+        public AvatarPreference AvatarPreference { get; internal set; }
     }
 }


### PR DESCRIPTION
There have been some revisions to the BIMI draft since this code was touched.

https://author-tools.ietf.org/iddiff?url1=draft-brand-indicators-for-message-identification-04&url2=draft-brand-indicators-for-message-identification-08&difftype=--html

This change adds the newly added avatar preference tag, described in section [4.3](https://datatracker.ietf.org/doc/html/draft-brand-indicators-for-message-identification-08#section-4.3) of the spec.