### PR TITLE
Update avatar preference tag

### DIFF
--- a/BusinessMonitor.MailTools.Test/BimiTests.cs
+++ b/BusinessMonitor.MailTools.Test/BimiTests.cs
@@ -33,12 +33,12 @@ namespace BusinessMonitor.MailTools.Test
         [Test]
         public void TestAvatar()
         {
-            var record = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; s=personal");
+            var record = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; avp=personal");
 
             Assert.That(record, Is.Not.Null);
             Assert.That(record.AvatarPreference, Is.EqualTo(AvatarPreference.Personal));
 
-            var record2 = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; s=bimi");
+            var record2 = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; avp=bimi");
 
             Assert.That(record2, Is.Not.Null);
             Assert.That(record2.AvatarPreference, Is.EqualTo(AvatarPreference.Bimi));
@@ -67,7 +67,7 @@ namespace BusinessMonitor.MailTools.Test
         [TestCase("v=BIMI1; l=invalidlink")]
         [TestCase("v=BIMI1; a=invalidlink l=https://businessmonitor.nl/logo.svg")]
         [TestCase("v=BIMI1; l=http://nothttpstransport")]
-        [TestCase("v=BIMI1; l=https://example.com/logo.svg; s=invalid")]
+        [TestCase("v=BIMI1; l=https://example.com/logo.svg; avp=invalid")]
         public void TestInvalid(string value)
         {
             Assert.Throws<BimiInvalidException>(() =>

--- a/BusinessMonitor.MailTools/Bimi/BimiCheck.cs
+++ b/BusinessMonitor.MailTools/Bimi/BimiCheck.cs
@@ -113,7 +113,9 @@ namespace BusinessMonitor.MailTools.Bimi
                         break;
 
                     // Avatar Preference
+                    // TODO remove the s= tag after a while
                     case "s":
+                    case "avp":
                         record.AvatarPreference = GetAvatarPreference(val);
 
                         break;


### PR DESCRIPTION
They recently updated the BIMI draft and this revision changes the avatar preference tag from s= to avp=.

https://author-tools.ietf.org/iddiff?url1=draft-brand-indicators-for-message-identification-08&url2=draft-brand-indicators-for-message-identification-09&difftype=--html

The old s= tag is kept for backward compatibility but should be removed when the standard is finalized (if they ever will).