### PR TITLE
Update avatar preference values

### DIFF
--- a/BusinessMonitor.MailTools.Test/BimiTests.cs
+++ b/BusinessMonitor.MailTools.Test/BimiTests.cs
@@ -38,15 +38,15 @@ namespace BusinessMonitor.MailTools.Test
             Assert.That(record, Is.Not.Null);
             Assert.That(record.AvatarPreference, Is.EqualTo(AvatarPreference.Personal));
 
-            var record2 = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; avp=bimi");
+            var record2 = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; avp=brand");
 
             Assert.That(record2, Is.Not.Null);
-            Assert.That(record2.AvatarPreference, Is.EqualTo(AvatarPreference.Bimi));
+            Assert.That(record2.AvatarPreference, Is.EqualTo(AvatarPreference.Brand));
 
             var record3 = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg");
 
             Assert.That(record3, Is.Not.Null);
-            Assert.That(record3.AvatarPreference, Is.EqualTo(AvatarPreference.Bimi));
+            Assert.That(record3.AvatarPreference, Is.EqualTo(AvatarPreference.Brand));
         }
 
         [Test]

--- a/BusinessMonitor.MailTools/Bimi/AvatarPreference.cs
+++ b/BusinessMonitor.MailTools/Bimi/AvatarPreference.cs
@@ -3,6 +3,6 @@
     public enum AvatarPreference
     {
         Personal,
-        Bimi
+        Brand
     }
 }

--- a/BusinessMonitor.MailTools/Bimi/BimiCheck.cs
+++ b/BusinessMonitor.MailTools/Bimi/BimiCheck.cs
@@ -113,7 +113,7 @@ namespace BusinessMonitor.MailTools.Bimi
                         break;
 
                     // Avatar Preference
-                    // TODO remove the s= tag after a while
+                    // TODO s= tag was removed in v9, remove when spec no longer is a draft
                     case "s":
                     case "avp":
                         record.AvatarPreference = GetAvatarPreference(val);
@@ -159,12 +159,13 @@ namespace BusinessMonitor.MailTools.Bimi
 
         private static AvatarPreference GetAvatarPreference(string value)
         {
-            if (value != "personal" && value != "bimi")
+            // TODO bimi value was removed in v10, remove when spec no longer is a draft
+            if (value != "personal" && value != "brand" && value != "bimi")
             {
-                throw new BimiInvalidException("Invalid avatar preference, must be personal or bimi");
+                throw new BimiInvalidException("Invalid avatar preference, must be personal or brand");
             }
 
-            return value == "personal" ? AvatarPreference.Personal : AvatarPreference.Bimi;
+            return value == "personal" ? AvatarPreference.Personal : AvatarPreference.Brand;
         }
     }
 }

--- a/BusinessMonitor.MailTools/Bimi/BimiRecord.cs
+++ b/BusinessMonitor.MailTools/Bimi/BimiRecord.cs
@@ -9,7 +9,7 @@
         {
             Evidence = "";
             Location = null;
-            AvatarPreference = AvatarPreference.Bimi;
+            AvatarPreference = AvatarPreference.Brand;
         }
 
         /// <summary>


### PR DESCRIPTION
The avatar preference values have been updated in the spec after being suggested by @ben221199 in the mailing list.

https://author-tools.ietf.org/iddiff?url1=draft-brand-indicators-for-message-identification-09&url2=draft-brand-indicators-for-message-identification-10&difftype=--html

The old value has been kept for backward compatibility but should be removed in the future.