### PR TITLE
Add local-part selector tag

### DIFF
--- a/BusinessMonitor.MailTools.Test/BimiTests.cs
+++ b/BusinessMonitor.MailTools.Test/BimiTests.cs
@@ -31,6 +31,21 @@ namespace BusinessMonitor.MailTools.Test
         }
 
         [Test]
+        public void TestSelectors()
+        {
+            var record = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; lps=hello-world");
+
+            Assert.That(record, Is.Not.Null);
+            Assert.That(record.LocalPartSelectors, Contains.Item("hello-world"));
+
+            var record2 = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; lps=hello , world , yes");
+
+            Assert.That(record2, Is.Not.Null);
+            Assert.That(record2.LocalPartSelectors, Contains.Item("hello"));
+            Assert.That(record2.LocalPartSelectors, Contains.Item("world"));
+        }
+
+        [Test]
         public void TestAvatar()
         {
             var record = BimiCheck.ParseBimiRecord("v=BIMI1; l=https://example.com/logo.svg; avp=personal");
@@ -61,6 +76,9 @@ namespace BusinessMonitor.MailTools.Test
             Assert.That(record.Location, Is.EqualTo("https://businessmonitor.nl/logo.svg"));
         }
 
+        // Can't do new string() since const
+        private const string LongSelector = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
         [Test]
         [TestCase("")]
         [TestCase("v=BIMI1")]
@@ -68,6 +86,8 @@ namespace BusinessMonitor.MailTools.Test
         [TestCase("v=BIMI1; a=invalidlink l=https://businessmonitor.nl/logo.svg")]
         [TestCase("v=BIMI1; l=http://nothttpstransport")]
         [TestCase("v=BIMI1; l=https://example.com/logo.svg; avp=invalid")]
+        [TestCase("v=BIMI1; l=https://example.com/logo.svg; lps=???")]
+        [TestCase("v=BIMI1; l=https://example.com/logo.svg; lps=" + LongSelector)]
         public void TestInvalid(string value)
         {
             Assert.Throws<BimiInvalidException>(() =>

--- a/BusinessMonitor.MailTools/Bimi/BimiCheck.cs
+++ b/BusinessMonitor.MailTools/Bimi/BimiCheck.cs
@@ -1,5 +1,6 @@
 ﻿using BusinessMonitor.MailTools.Dns;
 using BusinessMonitor.MailTools.Exceptions;
+using BusinessMonitor.MailTools.Util;
 
 namespace BusinessMonitor.MailTools.Bimi
 {
@@ -112,6 +113,12 @@ namespace BusinessMonitor.MailTools.Bimi
 
                         break;
 
+                    // Local-Part Selector
+                    case "lps":
+                        record.LocalPartSelectors = GetLocalPartSelectors(val);
+
+                        break;
+
                     // Avatar Preference
                     // TODO s= tag was removed in v9, remove when spec no longer is a draft
                     case "s":
@@ -155,6 +162,26 @@ namespace BusinessMonitor.MailTools.Bimi
             {
                 throw new BimiInvalidException($"BIMI record {type} is invalid, transport must be HTTPS");
             }
+        }
+
+        private static string[] GetLocalPartSelectors(string value)
+        {
+            var selectors = value.SplitTrim(',');
+
+            foreach (var selector in selectors)
+            {
+                if (!selector.All(x => char.IsLetterOrDigit(x) || x == '-'))
+                {
+                    throw new BimiInvalidException("Invalid local-part selector, selector must only contain alphanumeric characters or dashes");
+                }
+
+                if (selector.Length > 63)
+                {
+                    throw new BimiInvalidException("Invalid local-part selector, selector must be at most 63 characters long");
+                }
+            }
+
+            return selectors;
         }
 
         private static AvatarPreference GetAvatarPreference(string value)

--- a/BusinessMonitor.MailTools/Bimi/BimiRecord.cs
+++ b/BusinessMonitor.MailTools/Bimi/BimiRecord.cs
@@ -9,6 +9,7 @@
         {
             Evidence = "";
             Location = null;
+            LocalPartSelectors = [];
             AvatarPreference = AvatarPreference.Brand;
         }
 
@@ -21,6 +22,11 @@
         /// Gets the location of the Brand Indicator file
         /// </summary>
         public string? Location { get; internal set; }
+
+        /// <summary>
+        /// Gets the local-part selectors
+        /// </summary>
+        public string[] LocalPartSelectors { get; internal set; }
 
         /// <summary>
         /// Gets the avatar preference

--- a/BusinessMonitor.MailTools/BusinessMonitor.MailTools.csproj
+++ b/BusinessMonitor.MailTools/BusinessMonitor.MailTools.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/BusinessMonitor.MailTools/Util/StringExtensions.cs
+++ b/BusinessMonitor.MailTools/Util/StringExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace BusinessMonitor.MailTools.Util
+{
+    internal static class StringExtensions
+    {
+        internal static string[] SplitTrim(this string value, char separator)
+        {
+            return value.Split([separator], StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToArray();
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+- [BIMI] Add the new local-part selector tag (https://github.com/markvantilburg/BusinessMonitor.MailTools/pull/11)
 - [BIMI] Update the new preference tag (https://github.com/markvantilburg/BusinessMonitor.MailTools/pull/10)
 
 ## v1.0.9


### PR DESCRIPTION
Adds the newly described local-part selector tag as described in the updated revision of the spec.

https://author-tools.ietf.org/iddiff?url1=draft-brand-indicators-for-message-identification-10&url2=draft-brand-indicators-for-message-identification-12&difftype=--html

Also updates the C# version to C# 12 to allow for some newer syntax, and some future clean up (PR coming after this is merged).